### PR TITLE
bump: version 1.0.16 → 1.0.19

### DIFF
--- a/.cz.yaml
+++ b/.cz.yaml
@@ -4,6 +4,6 @@ commitizen:
   name: cz_conventional_commits
   tag_format: $version
   update_changelog_on_bump: true
-  version: 1.0.16
+  version: 1.0.19
   version_provider: commitizen
   version_scheme: pep440

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 1.0.19 (2025-07-25)
+
+### Fix
+
+- fix action description add badge-marketplace to cron-tasks
+
+### Refactor
+
+- remove unused cron-tasks
+
 ## 1.0.16 (2025-07-22)
 
 ### Feat


### PR DESCRIPTION
### Summary
This PR bumps version from 1.0.16 to 1.0.19